### PR TITLE
Comment out line causing Py_DecRef crashes in the evals.

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -55,7 +55,12 @@ final class PyReference {
     }
 
     deinit {
-        Py_DecRef(pointer)
+        // AIQ-230: This is causing crashing in the evals.
+        // We don't use PythonKit in production, so in the absence of a proper fix
+        // we're commenting this out.
+        //
+        // This change should be reverted if we ever use PythonKit in production.
+        // Py_DecRef(pointer)
     }
 
     var borrowedPyObject: PyObjectPointer {


### PR DESCRIPTION
There is a long-standing issue where the evals will crash in PythonKit when `Py_DecRef(pointer)` is called.

The longer-running an eval is (e.g. more cases in the dataset), the more likely it is to crash.

Since we only use PythonKit in the evals and not in production, we can safely comment out this line to prevent the crashes.

But this change should be reverted if we ever use PythonKit in production.